### PR TITLE
Image refactoring (AMD64 version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A redis container is required, e.g redis:alpine to be linked to the xen orchestr
 To forward all external traffic from port 80 to the container’s port 8080
 
 ```sh
-$ docker run -d --name xen-orchestra -p 80:8080 yobasystems/alpine-xen-orchestra
+$ docker run -d --name xen-orchestra -p 80:8080 yobasystems/alpine-xen-orchestra yarn start
 ```
 
 Point your browser to `http://host-ip`.
@@ -67,6 +67,7 @@ services:
     xen-orchestra:
         image: yobasystems/alpine-xen-orchestra:latest
         container_name: xoa
+        command: yarn start
         ports:
             - "8000:8080"
         depends_on:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Xen Orchestra Docker image running on Alpine Linux
 
-[![Docker Layers](https://img.shields.io/badge/docker%20layers-9-blue.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/yobasystems/alpine-xen-orchestra/) [![Docker Size](https://img.shields.io/badge/docker%20size-198%20MB-blue.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/yobasystems/alpine-xen-orchestra/) [![Docker Stars](https://img.shields.io/docker/stars/yobasystems/alpine-xen-orchestra.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/yobasystems/alpine-xen-orchestra/) [![Docker Pulls](https://img.shields.io/docker/pulls/yobasystems/alpine-xen-orchestra.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/yobasystems/alpine-xen-orchestra/)
+[![Docker Layers](https://img.shields.io/badge/docker%20layers-9-blue.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/bastienm/alpine-xoa/) [![Docker Size](https://img.shields.io/badge/docker%20size-198%20MB-blue.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/bastienm/alpine-xoa/) [![Docker Stars](https://img.shields.io/docker/stars/bastienm/xoa.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/bastienm/alpine-xoa/) [![Docker Pulls](https://img.shields.io/docker/pulls/bastienm/alpine-xoa.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/bastienm/alpine-xoa/)
 
-[![Alpine Version](https://img.shields.io/badge/alpine%20version-v3.6.2-green.svg?maxAge=2592000?style=flat-square)](http://alpinelinux.org/) [![Xen Orchestra Version](https://img.shields.io/badge/xo%20version-v5.10.5-green.svg?maxAge=2592000?style=flat-square)](https://xen-orchestra.com/)
+[![Alpine Version](https://img.shields.io/badge/alpine%20version-v3.4.0-green.svg?maxAge=2592000?style=flat-square)](http://alpinelinux.org/) [![Xen Orchestra Version](https://img.shields.io/badge/xo%20version-v5.13.0-green.svg?maxAge=2592000?style=flat-square)](https://xen-orchestra.com/)
 
 This Docker image [(yobasystems/alpine-xen-orchestra)](https://hub.docker.com/r/yobasystems/alpine-xen-orchestra/) is based on the minimal [Alpine Linux](http://alpinelinux.org/) with [Xen Orchestra](https://xen-orchestra.com/).
 
-##### Alpine Version 3.6.2 (Released Jun 17, 2017)
-##### Xen Orchestra Version 5.10.5
+##### Alpine Version 3.4 (Released Apr 30, 2016)
+##### Xen Orchestra Version 5.13.0
 
 ----
 

--- a/alpine-xen-orchestra-amd64/Dockerfile
+++ b/alpine-xen-orchestra-amd64/Dockerfile
@@ -42,11 +42,9 @@ RUN echo $'\
     apk update -U && \
     apk add -U libstdc++ util-linux yarn@edge && \
     rm -rf /tmp/* /var/cache/apk/*
-
-WORKDIR /app
-
-COPY --from=server-builder /app/xo-server ./xo-server
-COPY --from=web-builder /app/xo-web/dist ./xo-web
+    
+COPY --from=server-builder /app/xo-server /app/xo-server
+COPY --from=web-builder /app/xo-web/dist /app/xo-web
 
 ADD files/config.yaml /etc/xo-server/config.yaml
 

--- a/alpine-xen-orchestra-amd64/Dockerfile
+++ b/alpine-xen-orchestra-amd64/Dockerfile
@@ -46,7 +46,7 @@ RUN echo $'\
 COPY --from=server-builder /app/xo-server /app/xo-server
 COPY --from=web-builder /app/xo-web/dist /app/xo-web
 
-ADD files/config.yaml /etc/xo-server/config.yaml
+COPY files/config.yaml /etc/xo-server/config.yaml
 
 RUN addgroup -S $USER && adduser -S -g $USER $USER && \
     mkdir -p /app/data && \

--- a/alpine-xen-orchestra-amd64/Dockerfile
+++ b/alpine-xen-orchestra-amd64/Dockerfile
@@ -45,19 +45,17 @@ RUN echo $'\
     
 COPY --from=server-builder /app/xo-server /app/xo-server
 COPY --from=web-builder /app/xo-web/dist /app/xo-web
-
 COPY files/config.yaml /etc/xo-server/config.yaml
+
+COPY files/entrypoint.sh /entrypoint.sh
 
 VOLUME /app/data
 
 RUN addgroup -S $USER && adduser -S -g $USER $USER && \
-    mkdir -p /app/data && \
-    chown -R $USER:$USER /app/data
+    chmod +x /entrypoint.sh
 
 EXPOSE 8080
 
-USER xenorchestra
+USER root
 
-WORKDIR /app/xo-server
-
-CMD ["yarn", "start"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine-xen-orchestra-amd64/Dockerfile
+++ b/alpine-xen-orchestra-amd64/Dockerfile
@@ -48,13 +48,13 @@ COPY --from=web-builder /app/xo-web/dist /app/xo-web
 
 COPY files/config.yaml /etc/xo-server/config.yaml
 
+VOLUME /app/data
+
 RUN addgroup -S $USER && adduser -S -g $USER $USER && \
     mkdir -p /app/data && \
-    chown -R $USER:$USER /app
+    chown -R $USER:$USER /app/data
 
 EXPOSE 8080
-
-VOLUME /app/data
 
 USER xenorchestra
 

--- a/alpine-xen-orchestra-amd64/Dockerfile
+++ b/alpine-xen-orchestra-amd64/Dockerfile
@@ -1,35 +1,65 @@
-FROM yobasystems/alpine-nodejs:amd64-min
-LABEL maintainer "Dominic Taylor <dominic@yobasystems.co.uk>" architecture="AMD64/x86_64"
-
-RUN apk update && \
-    apk add --no-cache build-base git curl python libstdc++ make gcc g++ libpng-dev nodejs-npm && \
-    echo -e 'http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/community\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing' > /etc/apk/repositories && \
-    apk update && apk add --no-cache yarn
+# Compiling xo-server sources
+FROM node:6-alpine as server-builder
 
 WORKDIR /app
 
+RUN apk update && \
+    apk add git build-base git curl python libstdc++ make gcc g++ libpng-dev && \
+    yarn global add node-gyp index-modules 
+
 RUN git clone -b stable https://github.com/vatesfr/xo-server && \
-    git clone -b stable https://github.com/vatesfr/xo-web && \
-    rm -rf xo-server/.git xo-web/.git xo-server/sample.config.yaml && \
-    yarn global add node-gyp && \
-    cd /app/xo-server && yarn && yarn run build && yarn clean && \
-    cd /app/xo-web && yarn && yarn run build && yarn clean && \
-    yarn global remove node-gyp && \
-    mv /app/xo-web/dist /app && rm -rf /app/xo-web && mv /app/dist /app/xo-web && \
-    apk del --no-cache build-base git curl python make gcc g++ libpng-dev && \
+    rm -rf xo-server/{.git,sample.config.yaml}
+
+RUN cd xo-server && yarn
+
+# Compiling xo-web sources
+FROM node:6-alpine as web-builder
+
+WORKDIR /app
+
+RUN apk update && \
+    apk add git build-base git curl python libstdc++ make gcc g++ libpng-dev && \
+    yarn global add node-gyp index-modules 
+
+RUN git clone -b stable https://github.com/vatesfr/xo-web && \
+    rm -rf xo-server/.git
+
+RUN cd xo-web && yarn
+
+# Compiling alpine-xen-orchestra
+FROM node:6-alpine
+
+LABEL maintainer "Dominic Taylor <dominic@yobasystems.co.uk>" \
+      architecture="AMD64/x86_64"
+
+ENV USER=xenorchestra \
+    USER_HOME=/app
+
+RUN echo $'\
+@edge http://dl-cdn.alpinelinux.org/alpine/edge/main\n\
+@edge http://dl-cdn.alpinelinux.org/alpine/edge/community\n\ 
+@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
+    apk update -U && \
+    apk add -U libstdc++ util-linux yarn@edge && \
     rm -rf /tmp/* /var/cache/apk/*
 
-ADD files/config.yaml /app/xo-server/.xo-server.yaml
-ADD files/entrypoint.sh /
+WORKDIR /app
 
-RUN chmod +x /entrypoint.sh && \
-    addgroup -S xenorchestra && adduser -S -g xenorchestra xenorchestra
+COPY --from=server-builder /app/xo-server ./xo-server
+COPY --from=web-builder /app/xo-web/dist ./xo-web
+
+ADD files/config.yaml /etc/xo-server/config.yaml
+
+RUN addgroup -S $USER && adduser -S -g $USER $USER && \
+    mkdir -p /app/data && \
+    chown -R $USER:$USER /app
 
 EXPOSE 8080
 
-ENV USER=xenorchestra USER_HOME=/app
-
 VOLUME /app/data
 
-ENTRYPOINT ["/entrypoint.sh"]
+USER xenorchestra
+
+WORKDIR /app/xo-server
+
 CMD ["yarn", "start"]

--- a/alpine-xen-orchestra-amd64/docker-compose.yml
+++ b/alpine-xen-orchestra-amd64/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
     xen-orchestra:
         image: yobasystems/alpine-xen-orchestra:latest
+        command: yarn start
         container_name: xoa
         ports:
             - "8000:8080"

--- a/alpine-xen-orchestra-amd64/files/entrypoint.sh
+++ b/alpine-xen-orchestra-amd64/files/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e
 
-# storge directory and fix perms
-mkdir -p /app/data
+# fix permissions on data folder
 chown -R xenorchestra:xenorchestra /app/data
 
 # start App


### PR DESCRIPTION
Hi,

I have been using your image for quite some time and figured out that some elements could be improved to further slim down its weight and optimize its build process.

## Changelog

Includes @volatilemolotov12 [fix](https://github.com/volatilemolotov12/alpine-xen-orchestra/commit/d3e51ecf80a9349379229a00850dd61d8ffb5f23) for Iosetup (#1) .

* Now using multistage build functionality to compile the sources inside their own containers in order to loose any unnecessary packages or temp files.

* Using standard node images (`node:6`) to do the compiling and to run the app (XOA is designed to works on Node v6 for LTS)

* Simplified the compiling process. A simple `yarn` is what suffice to trigger the whole process.

* ~~Got rid of the entrypoint as using both `ENTRYPOINT` and `CMD` is not recommended. Plus what the entrypoint was doing can be achieve during inside the Dockerfile.~~
Reverted to using `ENTRYPOINT` to fix the volume permissions mechanism.

* Using *pinned* repositories for `yarn` in the main image in order to keep the system clean and not mixing stable & edge packages.

* Minor syntax or aspect changes.

* Updated README with new Alpine version, image layers

## Actual state

The image only weighting **207MB** instead of the previous **560MB**.

```
$ docker images                                                                                                                           
bastienm/xoa                        latest              0c8df4701ebb        25 minutes ago      207MB
yobasystems/alpine-xen-orchestra    latest              08681be717b9        3 weeks ago         560MB
```

## Potential problems : 

**~~Still got some warnings to issue :~~** 
```
xoa              | [WARN] start error: Error: spawn vgchange ENOENT
xoa              |     at Process.ChildProcess._handle.onexit (internal/child_process.js:197:32)
xoa              |     at onErrorNT (internal/child_process.js:376:16)
xoa              |     at _combinedTickCallback (internal/process/next_tick.js:80:11)
xoa              |     at process._tickCallback (internal/process/next_tick.js:104:9)
xoa              | Warning: connect.session() MemoryStore is not
xoa              | designed for a production environment, as it will leak
xoa              | memory, and will not scale past a single process.
```

The seems to be linked with how the Xen Orchestra team handles some part of the application.

---

**Removing the entrypoint.sh was not without repercussion** 

~~Docker still has some issues working with volume's permissions. I'll get in touch with the devs to check what this leveldb is actually doing.~~
~~Ok, so the leveldb is actually where XO stored most (if not all) of its configuration.
Guess I'll revert to use the entrypoint to fix that while working on a better solution.~~
Fixed in the lasts commits (revert to using the entrypoint script).

```
[WARN] start error: Error: EACCES: permission denied, mkdir '/app/data/leveldb'
    at Error (native)
[WARN] start error: Error: EACCES: permission denied, mkdir '/app/data/leveldb'
    at Error (native)
[WARN] start error: Error: EACCES: permission denied, mkdir '/app/data/leveldb'
    at Error (native)
[WARN] start error: Error: EACCES: permission denied, mkdir '/app/data/leveldb'
    at Error (native)
```
